### PR TITLE
Replacements via ghsed

### DIFF
--- a/views/includes/html-head.html
+++ b/views/includes/html-head.html
@@ -175,7 +175,7 @@
 {
  "gpt": {
    "network": 5887,
-   "adUnit": "{{ ads.gptAdunit }}"
+   "site": "ft.com"
  },
  "dfp_targeting": "{{ ads.dftTargeting }}"
 }


### PR DESCRIPTION
Command invoked 2017-08-04T13:43:27.334Z with the following arguments:
```bash
$ ghsed s/"adUnit": "{{[^\n]*/"site": "ft.com"/ ft-interactive/*
```